### PR TITLE
Work around non-existant database error

### DIFF
--- a/mongo-stream.js
+++ b/mongo-stream.js
@@ -23,6 +23,8 @@ class MongoStream {
   static async init(options) {
     const client = await MongoClient.connect(options.url, options.mongoOpts);
     const db = client.db(options.db);
+    await db.createCollection('init');  // workaround for "MongoError: cannot open $changeStream for non-existent database"
+    await db.dropCollection('init');
     const elasticManager = new ElasticManager(options.elasticOpts, options.mappings, options.bulkSize);
     const resumeTokenInterval = options.resumeTokenInterval;
     const mongoStream = new MongoStream(elasticManager, db, resumeTokenInterval);


### PR DESCRIPTION
The error "MongoError: cannot open $changeStream for non-existent database" is thrown if Mongo-Stream tries to open a changeStream against an empty MongoDB. 

Creating an 'init' collection (then immediately deleting it) allows the changeStream to be opened and replicate changes as soon as the empty DB is seeded with data. 