### PR TITLE
support collection based storage for resume tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+.vscode
 node_modules
 *.env
 *.pem

--- a/CollectionManager.js
+++ b/CollectionManager.js
@@ -4,15 +4,15 @@ const fs = require('fs');
 const logger = new (require('service-logger'))(__filename);
 
 class CollectionManager {
-  constructor(db, collection, elasticManager) {
+  constructor(db, collection, elasticManager, resumeTokenCollection) {
     this.db = db;
     this.elasticManager = elasticManager;
     this.collection = collection;
     this.elasticManager.setMappings(collection);
-    this.resumeToken = this.getResumeToken();
+    this.resumeToken = null;
+    this.resumeTokenCollection = resumeTokenCollection;
     this.changeStream;
   }
-
   async dumpCollection() {
     const cursor = this.db.collection(this.collection).find({}, {});
     const count = await this.db.collection(this.collection).count();
@@ -57,9 +57,14 @@ class CollectionManager {
     logger.info('done');
   }
 
-  watch(ignoreResumeToken = false) {
+  async watch(ignoreResumeToken = false) {
     logger.info(`new watcher for collection ${this.collection}`);
-    if (ignoreResumeToken) this.resumeToken = null;
+    if (ignoreResumeToken) {
+      this.resumeToken = null;
+    } else {
+      await this.getResumeToken();
+    }
+
     this.changeStream = this.db.collection(this.collection).watch({resumeAfter: this.resumeToken, fullDocument: 'updateLookup'});
     this._addChangeListener();
     this._addCloseListener();
@@ -113,28 +118,68 @@ class CollectionManager {
     this.writeResumeToken();
   }
 
-  getResumeToken() {
+  hasResumeToken() {
+    return !!this.resumeToken;
+  }
+
+  async getResumeToken() {
     if (!this.resumeToken) {
-      try {
-        const base64Buffer = fs.readFileSync(`./resumeTokens/${this.collection}`);
-        this.resumeToken = bson.deserialize(base64Buffer);
-      } catch (err) {
-        this.resumeToken = null;
+      if (this.resumeTokenCollection) {
+        await this.getResumeTokenFromCollection();
+      } else {
+        this.getResumeTokenFromFile();
       }
     }
 
     return this.resumeToken;
   }
 
-  hasResumeToken() {
-    return !!this.resumeToken;
+  async getResumeTokenFromCollection() {
+    try {
+      const { token } = await this.db.collection(this.resumeTokenCollection).findOne({ _id: this.collection })
+      this.resumeToken = token;
+    } catch (err) {
+      logger.debug(`resumeToken for ${this.collection} could not be retrieved from database`);
+      this.resumeToken = null;
+    }
+  }
+
+  getResumeTokenFromFile() {
+    try {
+      const base64Buffer = fs.readFileSync(`./resumeTokens/${this.collection}`);
+      this.resumeToken = bson.deserialize(base64Buffer);
+    } catch (err) {
+      this.resumeToken = null;
+    }
   }
 
   writeResumeToken() {
     if (!this.resumeToken) return;
+
+    if (this.resumeTokenCollection) {
+      this.writeResumeTokenToCollection()
+    } else {
+      this.writeResumeTokenToFile();
+    }
+  }
+
+  writeResumeTokenToFile() {
     const b64String = bson.serialize(this.resumeToken).toString('base64');
     fs.writeFileSync(`./resumeTokens/${this.collection}`, b64String, 'base64');
     logger.debug(`resumeToken for collection ${this.collection} saved to disk`);
+  }
+
+  writeResumeTokenToCollection() {
+    try {
+      this.db.collection(this.resumeTokenCollection).updateOne(
+        { _id: this.collection },
+        { $set: { token: this.resumeToken }},
+        { upsert: true },
+      );
+      logger.debug(`resumeToken for collection ${this.collection} saved to database`);
+    } catch (err) {
+      logger.debug(`resumeToken for collection ${this.collection} could not be saved to database`);
+    }
   }
 
   removeResumeToken() {

--- a/config/default.json
+++ b/config/default.json
@@ -17,6 +17,7 @@
   "ignoreResumeTokensOnStart": false,
   "dumpOnStart": false,
   "resumeTokenInterval": 60000,
+  "resumeTokenCollection": "",
   "parentChildRelations":[{
     "parentCollection":"customer",
     "childCollection":"order",

--- a/configParser.js
+++ b/configParser.js
@@ -88,6 +88,7 @@ const initOpts = {
   },
   collections: CONFIG.mongo.collections,
   resumeTokenInterval: CONFIG.resumeTokenInterval,
+  resumeTokenCollection: CONFIG.resumeTokenCollection,
   ignoreResumeTokensOnStart: CONFIG.ignoreResumeTokensOnStart,
   dumpOnStart: CONFIG.dumpOnStart,
   parentChildRelations: parentChildRelations

--- a/mongo-stream.js
+++ b/mongo-stream.js
@@ -47,6 +47,7 @@ class MongoStream {
     const managerOptions = {
       dump: options.dumpOnStart,
       ignoreResumeTokens: options.ignoreResumeTokensOnStart,
+      resumeTokenCollection: options.resumeTokenCollection,
       watch: true
     };
 
@@ -68,7 +69,7 @@ class MongoStream {
     await this.removeCollectionManager(collections);
 
     for (const collection of collections) {
-      const collectionManager = new CollectionManager(this.db, collection, this.elasticManager);
+      const collectionManager = new CollectionManager(this.db, collection, this.elasticManager, options.resumeTokenCollection);
       if (options.dump) {
         await collectionManager.elasticManager.deleteElasticCollection(collection);
         await collectionManager.dumpCollection();


### PR DESCRIPTION
Hope this is OK for a first shot at it...

The functionality is controlled by populating the 'resumeTokenCollection' property in the config file. If the string value is left empty the file based resume token functionality will be used, but if a value is provided it will use the collection based storage instead.

The collection will be automatically created if it does not already exist.

As collections names must be unique in a database I've taken the liberty of using the collection name for the _id therefore making use of the automatic index on the field to save creating additional indexes and storing more fields in the source database than necessary.

I haven't implemented the removeResumeToken() function as I noticed it wasn't being called in any of the code base - I can easily add this if required but I didn't want to add dead code unnecessarily.

Let me know if you have any suggestions/changes or would like it implemented in a different manner.

Thanks!

fixes #41 
