### PR TITLE
support elasticsearch external document versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+.vscode
 node_modules
 *.env
 *.pem

--- a/CollectionManager.js
+++ b/CollectionManager.js
@@ -2,6 +2,7 @@ const BSON = require('bson');
 const bson = new BSON();
 const fs = require('fs');
 const logger = new (require('service-logger'))(__filename);
+const util = require('./util');
 
 class CollectionManager {
   constructor(db, collection, elasticManager) {
@@ -43,7 +44,9 @@ class CollectionManager {
           _index: this.elasticManager.mappings[this.collection].index,
           _type: this.elasticManager.mappings[this.collection].type,
           _id: _id,
-          _parent: nextObject[this.elasticManager.mappings[this.collection].parentId]
+          _parent: nextObject[this.elasticManager.mappings[this.collection].parentId],
+          _versionType: this.elasticManager.mappings[this.collection].versionType,
+          _version: util.getVersionAsInteger(nextObject[this.elasticManager.mappings[this.collection].versionField])
         }
       });
       bulkOp.push(nextObject);

--- a/config/default.json
+++ b/config/default.json
@@ -22,7 +22,9 @@
       "index": "test",
       "type": "$self",
       "parent": "customer",
-      "parentId": "customerId"
+      "parentId": "customerId",
+      "versionType": "external",
+      "versionField": "updatedAt"
     }
   },
   "logLevel": "info"

--- a/elasticManager.js
+++ b/elasticManager.js
@@ -1,5 +1,6 @@
 const elasticsearch = require('elasticsearch');
 const logger = new (require('service-logger'))(__filename);
+const util = require('./util');
 
 class ElasticManager {
   constructor(elasticOpts, mappings, bulkSize) {
@@ -47,7 +48,9 @@ class ElasticManager {
           _index: this.mappings[changeStreamObj.ns.coll].index,
           _type: this.mappings[changeStreamObj.ns.coll].type,
           _id: esId,
-          _parent: esReadyDoc[this.mappings[changeStreamObj.ns.coll].parentId]
+          _parent: esReadyDoc[this.mappings[changeStreamObj.ns.coll].parentId],
+          _versionType: this.mappings[changeStreamObj.ns.coll].versionType,
+          _version: util.getVersionAsInteger(esReadyDoc[this.mappings[changeStreamObj.ns.coll].versionField])
         }
       });
     this.bulkOp.push(esReadyDoc);
@@ -56,8 +59,8 @@ class ElasticManager {
   async deleteDoc(changeStreamObj) {
     const esId = changeStreamObj.documentKey._id.toString(); // convert mongo ObjectId to string
 
-    const parentId = await this.findParentId(this.mappings[changeStreamObj.ns.coll], esId).catch((err) => {
-      logger.error(`error finding parentId in delete: ${err}`);
+    const { parentId, version } = await this.getExistingDoc(this.mappings[changeStreamObj.ns.coll], esId).catch((err) => {
+      logger.error(`error finding existing document in delete: ${err}`);
     });
 
     this.bulkOp.push({
@@ -65,25 +68,30 @@ class ElasticManager {
         _index: this.mappings[changeStreamObj.ns.coll].index,
         _type: this.mappings[changeStreamObj.ns.coll].type,
         _id: esId,
-        _parent: parentId
+        _parent: parentId,
+        _versionType: this.mappings[changeStreamObj.ns.coll].versionType,
+        _version: util.incrementVersionForDeletion(version),
       }
     });
   }
 
-//find a parent Id of a document by searching for the document and pulling that Id out.
-//returns null if the collection is not a child collection or does not contain a document with the given Id.
-  async findParentId(collection, childId){
-    let doc = await this.esClient.search({
-      index: collection.index,
-      type: collection.type,
-      q: `_id:${childId}`
-    });
+  async getExistingDoc(collection, id) {
     try {
-      return doc.hits.hits[0]._parent
+      const doc = await this.esClient.search({
+        index: collection.index,
+        type: collection.type,
+        q: `_id:${id}`,
+        size: 1,
+        version: true,
+      });
+
+      return {
+        parentId: doc.hits.hits[0]._parent || null,
+        version: doc.hits.hits[0]._version || null,
+      }
     } catch(err) {
-      logger.error(`cannot find item of type ${collection.type} with id ${childId}`);
+      logger.error(`cannot find item of type ${collection.type} with id ${id}`);
     }
-    return null;
   }
 
   // delete all docs in ES before dumping the new docs into it
@@ -95,7 +103,8 @@ class ElasticManager {
         index: this.mappings[collectionName].index,
         type: this.mappings[collectionName].type,
         size: this.bulkSize,
-        scroll: '1m'
+        scroll: '1m',
+        version: true,
       });
     }
     catch (err) {
@@ -114,7 +123,9 @@ class ElasticManager {
             _index: this.mappings[collectionName].index,
             _type: this.mappings[collectionName].type,
             _id: dumpDocs[j]._id,
-            _parent: dumpDocs[j]._parent
+            _parent: dumpDocs[j]._parent,
+            _versionType: this.mappings[collectionName].versionType,
+            _version: util.incrementVersionForDeletion(dumpDocs[j]._version),
           }
         });
       }

--- a/util.js
+++ b/util.js
@@ -1,0 +1,5 @@
+exports.getVersionAsInteger = version => (version instanceof Date) ? version.getTime() : version;
+
+// Manually increment existing doc version number by 1 (if not null) to enable ES to perform deletion of the
+// versioned document (since we don't get a fullDocument from Mongo for 'delete' change events)
+exports.incrementVersionForDeletion = version => Number.isInteger(version) ? version++ : null;


### PR DESCRIPTION
Support for ElasticSearch External Document Versioning as detailed [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/docs-index_.html#index-versioning)

Configured as part of the mappings object on a per collection basis with these new properties:

`versionType:` One of `"external"` / `"external_gt"` / `"external_gte"`

`versionField:` The field in the source Mongo document to be used for the external version number. If the field value is an ISODate string it will automatically be converted into Unix Time (milliseconds since epoch) as ES only supports integer values for version numbers. This is useful when the versioning is based on a timestamp such as 'createdAt' or 'updatedAt' (for example).

If the both fields are omitted then ES will use its default internal versioning.

Let me know if you have any suggestions/concerns with the implementation.