### PR TITLE
fix to prevent error being throw when fullDocument is null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+.vscode
 node_modules
 *.env
 *.pem

--- a/elasticManager.js
+++ b/elasticManager.js
@@ -38,6 +38,7 @@ class ElasticManager {
 
 // insert event format https://docs.mongodb.com/manual/reference/change-events/#insert-event
   insertDoc(changeStreamObj) {
+    if (changeStreamObj.fullDocument === null) return;
     const esId = changeStreamObj.fullDocument._id.toString(); // convert mongo ObjectId to string
     delete changeStreamObj.fullDocument._id;
     const esReadyDoc = changeStreamObj.fullDocument;


### PR DESCRIPTION
We've discovered that when an update operation occurs on a MongoDB document followed very quickly by a deletion of the same document the change stream fullDocument field is null on the change stream update event (even though it came before the delete operation). I believe this happens due to the delete being processed before the find operation for the fullDocument field has taken place.

This fix prevents Mongo Stream from crashing when this situation occurs.

Example of the issue from Mongo Shell

`{
        "_id" : {
                "_data" : BinData(0,"glsDFjYAAAADRjxfaWQAPFduZGhQNlo2cFpuSGo0cDNHAABaEAQ5xIMX0OdGaL22w1YYaPs2BA==")
        },
        "operationType" : "update",
        "fullDocument" : null,
        "ns" : {
                "db" : "dev",
                "coll" : "Deliveries"
        },
        "documentKey" : {
                "_id" : "WndhP6Z6pZnHj4p3G"
        },
        "updateDescription" : {
                "updatedFields" : {
                        "deliveryTotalValue" : 0,
                        "updated" : ISODate("2018-05-21T18:55:50.941Z")
                },
                "removedFields" : [ ]
        }
}
`

`
{
        "_id" : {
                "_data" : BinData(0,"glsDFjYAAAAERjxfaWQAPFduZGhQNlo2cFpuSGo0cDNHAABaEAQ5xIMX0OdGaL22w1YYaPs2BA==")
        },
        "operationType" : "delete",
        "ns" : {
                "db" : "dev",
                "coll" : "Deliveries"
        },
        "documentKey" : {
                "_id" : "WndhP6Z6pZnHj4p3G"
        }
}`
