### PR TITLE
allow collection dump when not using Mongo ObjectID for identifiers

### DIFF
--- a/lib/CollectionManager.js
+++ b/lib/CollectionManager.js
@@ -25,7 +25,10 @@ class CollectionManager {
   }
 
   async dumpCollection() {
-    let cursor = this.collection.find({"_id":{$gt:this.dumpProgress.token}});
+    const query = this.dumpProgress.count
+      ? { _id: { $gt: this.dumpProgress.token } }
+      : {};
+    let cursor = this.collection.find(query);
     const count = (await cursor.count()) + this.dumpProgress.count;
 
     let bulkOp = [];


### PR DESCRIPTION
We experienced an issue with not being able to perform a collection dump using the dumpOnStart option ever since the changes that introduced dump progress support were merged.

The issue was traced to us using non Mongo ObjectID's as document identifiers. We use Meteor and by default it uses a 17 character length string generated randomly for database document identifiers rather than the standard Mongo ObjectID format.

As a result the dump query would never return any results - this small change allows a dump to proceed by check if dumpProgress.count is truthy or falsy and returning an appropriate query - although it does not provide dumpProgress support, which would be impossible in our case as the ID does not contain any form of timestamp, it does allow the dump process to synchronise documents between Mongo and ES.