### PR TITLE
Support for Elastic API v.6.x by using unique index names

### DIFF
--- a/lib/CollectionManager.js
+++ b/lib/CollectionManager.js
@@ -86,7 +86,7 @@ class CollectionManager {
       delete nextObject._id;
       bulkOp.push({
         index:  {
-          _index: CollectionManager.elasticManager.mappings[this.collectionName].index,
+          _index: CollectionManager.elasticManager.getESIndexName(this.collectionName),
           _type: CollectionManager.elasticManager.mappings[this.collectionName].type,
           _id: this.dumpProgress.token,
           _parent: nextObject[CollectionManager.elasticManager.mappings[this.collectionName].parentId],

--- a/lib/CollectionManager.js
+++ b/lib/CollectionManager.js
@@ -144,7 +144,9 @@ class CollectionManager {
       logger.error(`${this.collectionName} changeStream error:`, error);
       // 40585: resume of change stream was not possible, as the resume token was not found
       // 40615: The resume token UUID does not exist. Has the collection been dropped?
-      if (error.code === 40585 || error.code === 40615) {
+      // 260: InvalidResumeToken. Attempted to resume a stream on a collection which has been dropped.
+      // https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
+      if (error.code === 40585 || error.code === 40615 || error.code === 260) {
         this.resetChangeStream({ignoreResumeToken: true});
       }
       else {

--- a/lib/elasticManager.js
+++ b/lib/elasticManager.js
@@ -10,6 +10,7 @@ class ElasticManager {
     this.bulkSize = bulkSize;
     this.bulkOp = [];
     this.interval = null;
+    this.useDistinctIndexNames = elasticOpts && elasticOpts.apiVersion && parseInt(elasticOpts.apiVersion[0]) >= 6;
   }
 
   // Calls the appropriate replication function based on the change object parsed from a change stream
@@ -37,17 +38,22 @@ class ElasticManager {
       logger.error(`REPLICATION ERROR: ${change.operationType} is not a supported function`);
     }
   }
-
+  getESIndexName(collectionName) {
+    const indexName = this.mappings[collectionName].index;
+    const typeName = this.mappings[collectionName].type;
+    if (this.useDistinctIndexNames) return indexName + '-' + typeName;
+    return indexName;
+  }
 // insert event format https://docs.mongodb.com/manual/reference/change-events/#insert-event
   insertDoc(changeStreamObj) {
     if (changeStreamObj.fullDocument === null) return;
     const esId = changeStreamObj.fullDocument._id.toString(); // convert mongo ObjectId to string
     delete changeStreamObj.fullDocument._id;
     const esReadyDoc = changeStreamObj.fullDocument;
-
+console.log('****', this.getESIndexName(changeStreamObj.ns.coll));
     this.bulkOp.push({
         index:  {
-          _index: this.mappings[changeStreamObj.ns.coll].index,
+          _index: this.getESIndexName(changeStreamObj.ns.coll),
           _type: this.mappings[changeStreamObj.ns.coll].type,
           _id: esId,
           _parent: esReadyDoc[this.mappings[changeStreamObj.ns.coll].parentId],
@@ -77,14 +83,12 @@ class ElasticManager {
 
   async deleteDoc(changeStreamObj) {
     const esId = changeStreamObj.documentKey._id.toString(); // convert mongo ObjectId to string
-
-    const { parentId, version } = await this.getExistingDoc(this.mappings[changeStreamObj.ns.coll], esId).catch((err) => {
+    const { parentId, version } = await this.getExistingDoc(changeStreamObj.ns.coll, esId).catch((err) => {
       logger.error(`error finding existing document in delete: ${err}`);
      });
-
     this.bulkOp.push({
       delete: {
-        _index: this.mappings[changeStreamObj.ns.coll].index,
+        _index: this.getESIndexName(changeStreamObj.ns.coll),
         _type: this.mappings[changeStreamObj.ns.coll].type,
         _id: esId,
         _parent: parentId,
@@ -94,14 +98,14 @@ class ElasticManager {
     });
   }
 
-  async getExistingDoc(collection, id) {
+  async getExistingDoc(collectionName, id) {
     try {
       const doc = await this.esClient.search({
-        index: collection.index,
-        type: collection.type,
+        index: this.getESIndexName(collectionName),
+        type: this.mappings[collectionName].type,
         q: `_id:${id}`,
         size: 1,
-        version: Boolean(collection.versionType),
+        version: Boolean(this.mappings[collectionName].versionType),
       });
 
       return {
@@ -109,7 +113,7 @@ class ElasticManager {
         version: doc.hits.hits[0]._version || null,
       }
     } catch(err) {
-      logger.error(`cannot find item of type ${collection.type} with id ${id}`);
+      logger.error(`cannot find item of type ${this.mappings[collectionName].type} with id ${id}`);
     }
   }
 
@@ -119,7 +123,7 @@ class ElasticManager {
     try {
       // First get a count for all ES docs of the specified type
       searchResponse = await this.esClient.search({
-        index: this.mappings[collectionName].index,
+        index: this.getESIndexName(collectionName),
         type: this.mappings[collectionName].type,
         size: this.bulkSize,
         scroll: '1m',
@@ -139,7 +143,7 @@ class ElasticManager {
       for (let j = 0; j < dumpDocs.length; j++) {
         bulkDelete.push({
           delete: {
-            _index: this.mappings[collectionName].index,
+            _index: this.getESIndexName(collectionName),
             _type: this.mappings[collectionName].type,
             _id: dumpDocs[j]._id,
             _parent: dumpDocs[j]._parent,

--- a/lib/elasticManager.js
+++ b/lib/elasticManager.js
@@ -40,8 +40,7 @@ class ElasticManager {
   }
   getESIndexName(collectionName) {
     const indexName = this.mappings[collectionName].index;
-    const typeName = this.mappings[collectionName].type;
-    if (this.useDistinctIndexNames) return indexName + '-' + typeName;
+    if (this.useDistinctIndexNames) return indexName + '-' + collectionName;
     return indexName;
   }
 // insert event format https://docs.mongodb.com/manual/reference/change-events/#insert-event

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "elasticsearch": "14.1.0",
     "express": "4.16.2",
     "json-patch": "0.7.0",
-    "mongodb": "3.1.0",
+    "mongodb": "3.5.3",
     "service-logger": "1.0.3"
   }
 }


### PR DESCRIPTION
This PR adds a basic support for ElasticSearch v.6.x. As far as I can tell, the major difference in v.6 that breaks the original mongo-stream code is a requirement for unique index names. That is, each type should be stored in its own index (as opposed to multiple types in single index).

In this PR, if the options file specifies "apiVersion": "6.x", the proposed change composes index names as INDEX_NAME-TYPE_NAME. Otherwise, index names remain INDEX_NAME as in the original code.